### PR TITLE
fix: 🐛 make time line dots always centered in safari

### DIFF
--- a/src/components/TimeLine.jsx
+++ b/src/components/TimeLine.jsx
@@ -6,6 +6,7 @@ import { colors, mediaQueries } from '../styles';
 const timeLineDot = css`
   position: absolute;
   left: 74px;
+  top: calc(50% - 6px);
   background-color: ${colors.blue};
   border-radius: 50%;
   width: 12px;


### PR DESCRIPTION
Flexbox wasn't working great in safari for alignment, adding a calc for
top attribute as well.